### PR TITLE
Fix predefined literals from being used as lval

### DIFF
--- a/FrontEnd/FrontEnd.cpp
+++ b/FrontEnd/FrontEnd.cpp
@@ -632,6 +632,12 @@ void cs6300::AddConstant(char* ident, int expr)
   state->getSymTable()->addConstant(ident, e);
   delete (ident);
 }
+void cs6300::AddLiteral(std::string ident, int expr)
+{
+    auto state = FrontEndState::instance();
+    auto e = state->expressions.get(expr);
+    state->getSymTable()->addConstant(ident, e);
+}
 void cs6300::AddFunction(int signature)
 {
   auto state = FrontEndState::instance();
@@ -662,6 +668,13 @@ void cs6300::AddMain(int body)
   b->push_back(std::make_shared<cs6300::StopStatement>());
   auto program = state->getProgram();
   std::copy(b->begin(), b->end(), std::back_inserter(program->main));
+
+  int t = state->expressions.add(std::make_shared<cs6300::LiteralExpression>(1));
+  int f = state->expressions.add(std::make_shared<cs6300::LiteralExpression>(0));
+  AddLiteral("true",t);
+  AddLiteral("TRUE",t);
+  AddLiteral("false",f);
+  AddLiteral("FALSE",f);
 }
 void cs6300::AddType(char* ident, int typeIndex)
 {

--- a/FrontEnd/FrontEnd.hpp
+++ b/FrontEnd/FrontEnd.hpp
@@ -66,6 +66,7 @@ int While(int expr, int statement);
 int WriteExpr(int expr);
 int WriteExpr(int statment,int expr);
 void AddConstant(char *, int);
+void AddLiteral(std::string, int);
 void AddFunction(int signature);
 void AddFunction(int signature,int body);
 void AddMain(int);


### PR DESCRIPTION
This fixes the while loop crash I saw. I see other tests failing, will work on those too.
