### PR TITLE
Fix records part 2

### DIFF
--- a/AST_INC/AST/LValue.hpp
+++ b/AST_INC/AST/LValue.hpp
@@ -65,7 +65,7 @@ public:
   std::shared_ptr<Expression> address() const
   {
     int offset = 0;
-    auto pSymbol = m_table->lookupVariable(field);
+    auto pSymbol = m_table->lookupRecordVariable(field, base->type());
     if(pSymbol)
       offset = pSymbol->memory_offset;
 

--- a/AST_INC/AST/SymbolTable.cpp
+++ b/AST_INC/AST/SymbolTable.cpp
@@ -3,7 +3,7 @@
 #include "Expressions/Expression.hpp"
 #include "Type.hpp"
 #include <map>
-#include <string>
+#include <sstream>
 #include "Symbol.hpp"
 
 std::shared_ptr<cs6300::Type> cs6300::SymbolTable::lookupType(std::string id)
@@ -20,6 +20,17 @@ std::shared_ptr<cs6300::Symbol> cs6300::SymbolTable::lookupVariable(
   auto found = m_variables.find(id);
   if (found != m_variables.end()) return found->second;
   if (m_parent) return m_parent->lookupVariable(id);
+  return nullptr;
+}
+
+std::shared_ptr<cs6300::Symbol> cs6300::SymbolTable::lookupRecordVariable(
+  std::string id, std::shared_ptr<Type> type)
+{
+  std::stringstream idStrm;
+  idStrm << id << type;
+  auto found = m_variables.find(idStrm.str());
+  if (found != m_variables.end()) return found->second;
+  if (m_parent) return m_parent->lookupRecordVariable(id, type);
   return nullptr;
 }
 
@@ -61,3 +72,17 @@ void cs6300::SymbolTable::addVariable(std::string id,
   }
  m_memory_offset += type->size();
 }
+
+void cs6300::SymbolTable::addRecordVariable(std::string id,
+                                            std::shared_ptr<Type> type)
+{
+  std::stringstream idStrm;
+  idStrm << id << type;
+  auto found = m_variables.find(idStrm.str());
+  if (found == m_variables.end())
+  {
+      m_variables[idStrm.str()] = std::make_shared<Symbol>(id, type,  m_memory_offset , m_memorylocation);
+  }
+ m_memory_offset += type->size();
+}
+

--- a/AST_INC/AST/SymbolTable.hpp
+++ b/AST_INC/AST/SymbolTable.hpp
@@ -30,10 +30,12 @@ public:
 
   std::shared_ptr<Type> lookupType(std::string id);
   std::shared_ptr<Symbol> lookupVariable(std::string id);
+  std::shared_ptr<Symbol> lookupRecordVariable(std::string id, std::shared_ptr<Type> type);
   std::shared_ptr<Expression> lookupConstant(std::string id);
   void addConstant(std::string id, std::shared_ptr<Expression>);
   void addType(std::string id, std::shared_ptr<Type>);
   void addVariable(std::string id, std::shared_ptr<Type> type);
+  void addRecordVariable(std::string id, std::shared_ptr<Type> type);
 
   cs6300::MemoryLocation getMemoryLocation() { return m_memorylocation; }
 


### PR DESCRIPTION
Record member variables were replacing variables of the same name in the symbol table.  These changes fix that.  I also updated the existing pull to add record.cpsl to CS5300/TestFiles:
https://github.com/ksundberg/CS5300/pull/18
