### PR TITLE
Add FlowGraph type and flowgraph dot generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ parser.cpp
 parser.hpp
 scanner.cpp
 tags
+cscope*

--- a/AST_INC/AST/BasicBlock.hpp
+++ b/AST_INC/AST/BasicBlock.hpp
@@ -19,7 +19,7 @@ public:
   std::vector<ThreeAddressInstruction> instructions;
   std::shared_ptr<BasicBlock> jumpTo;
   std::shared_ptr<BasicBlock> branchTo;
-  std::vector<std::shared_ptr<BasicBlock>> parents;
+  std::set<std::shared_ptr<BasicBlock>> parents;
   int branchOn;
   std::string getLabel();
 

--- a/AST_INC/AST/BasicBlock.hpp
+++ b/AST_INC/AST/BasicBlock.hpp
@@ -11,6 +11,7 @@
 
 namespace cs6300
 {
+
 class BasicBlock
 {
 
@@ -31,5 +32,8 @@ public:
 private:
   std::string label;
 };
+
+typedef std::pair<std::shared_ptr<cs6300::BasicBlock>, std::shared_ptr<cs6300::BasicBlock>> FlowGraph;
+
 }
 #endif

--- a/AST_INC/AST/Program.hpp
+++ b/AST_INC/AST/Program.hpp
@@ -47,10 +47,8 @@ public:
       functions.insert(std::make_pair(f.first, emitList(f.second->body)));
     }
   }
-  std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>> main;
-  std::map<cs6300::FunctionSignature,
-           std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>>>
-    functions;
+  cs6300::FlowGraph main;
+  std::map<cs6300::FunctionSignature, cs6300::FlowGraph> functions;
 };
 }
 

--- a/AST_INC/AST/Statements/Assignment.cpp
+++ b/AST_INC/AST/Statements/Assignment.cpp
@@ -2,9 +2,7 @@
 #include "AST/Type.hpp"
 #include "AST/ThreeAddressInstruction.hpp"
 
-std::pair<std::shared_ptr<cs6300::BasicBlock>,
-          std::shared_ptr<cs6300::BasicBlock>>
-cs6300::Assignment::emit()
+cs6300::FlowGraph cs6300::Assignment::emit()
 {
   auto block = expr->emit();
   auto addr = lval->address();

--- a/AST_INC/AST/Statements/Assignment.hpp
+++ b/AST_INC/AST/Statements/Assignment.hpp
@@ -17,7 +17,7 @@ namespace cs6300
       {
       }
 
-    std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>> emit();
+      cs6300::FlowGraph emit();
     private:
       std::shared_ptr<LValue> lval;
       std::shared_ptr<Expression> expr;

--- a/AST_INC/AST/Statements/Call.cpp
+++ b/AST_INC/AST/Statements/Call.cpp
@@ -3,9 +3,7 @@
 #include "AST/ThreeAddressInstruction.hpp"
 #include "AST/SymbolTable.hpp"
 
-std::pair<std::shared_ptr<cs6300::BasicBlock>,
-          std::shared_ptr<cs6300::BasicBlock>>
-cs6300::Call::emit()
+cs6300::FlowGraph cs6300::Call::emit()
 {
   auto block = std::make_shared<BasicBlock>();
     

--- a/AST_INC/AST/Statements/Call.hpp
+++ b/AST_INC/AST/Statements/Call.hpp
@@ -18,7 +18,7 @@ namespace cs6300
           , arguments(args)
       {
       }
-    std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>> emit();
+      cs6300::FlowGraph emit();
 
     private:
       int label;

--- a/AST_INC/AST/Statements/For.cpp
+++ b/AST_INC/AST/Statements/For.cpp
@@ -8,9 +8,7 @@
 #include "AST/Expressions/SuccessorExpression.hpp"
 #include "AST/Expressions/LtExpression.hpp"
 
-std::pair<std::shared_ptr<cs6300::BasicBlock>,
-          std::shared_ptr<cs6300::BasicBlock>>
-cs6300::ForStatement::emit()
+cs6300::FlowGraph cs6300::ForStatement::emit()
 {
   Assignment assign(std::make_shared<IdAccess>(loopVariable,table), begin);
   auto init = assign.emit();

--- a/AST_INC/AST/Statements/For.hpp
+++ b/AST_INC/AST/Statements/For.hpp
@@ -33,7 +33,7 @@ class ForStatement : public Statement
           , table(t)
       {
       }
-    std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>> emit();
+      cs6300::FlowGraph emit();
 
     private:
       std::string loopVariable;

--- a/AST_INC/AST/Statements/If.cpp
+++ b/AST_INC/AST/Statements/If.cpp
@@ -1,7 +1,7 @@
 #include "If.hpp"
 #include <memory>
 
-std::pair<std::shared_ptr<cs6300::BasicBlock>, std::shared_ptr<cs6300::BasicBlock>> cs6300::IfStatement::emit()
+cs6300::FlowGraph cs6300::IfStatement::emit()
 {
   auto entryPoint = std::make_shared<BasicBlock>();
   auto cur = entryPoint;

--- a/AST_INC/AST/Statements/If.hpp
+++ b/AST_INC/AST/Statements/If.hpp
@@ -2,6 +2,7 @@
 #define CS6300_IF_STATEMENT_HPP
 
 #include "Statement.hpp"
+#include "AST/BasicBlock.hpp"
 #include "AST/Expressions/Expression.hpp"
 
 #include <string>
@@ -12,8 +13,7 @@ namespace cs6300
 class IfStatement : public Statement
   {
     public:
-      typedef std::pair<std::shared_ptr<Expression>,
-                        std::vector<std::shared_ptr<Statement>>> clause_t;
+      typedef std::pair<std::shared_ptr<Expression>, std::vector<std::shared_ptr<Statement>>> clause_t;
       IfStatement(std::vector<clause_t> c,
                   std::vector<std::shared_ptr<Statement>> e)
           : Statement()
@@ -21,7 +21,7 @@ class IfStatement : public Statement
           , elseClause(e)
       {
       }
-    std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>> emit();
+      cs6300::FlowGraph emit();
 
     private:
       std::vector<clause_t> clauses;

--- a/AST_INC/AST/Statements/Read.cpp
+++ b/AST_INC/AST/Statements/Read.cpp
@@ -2,9 +2,7 @@
 #include "AST/Type.hpp"
 #include "AST/ThreeAddressInstruction.hpp"
 
-std::pair<std::shared_ptr<cs6300::BasicBlock>,
-          std::shared_ptr<cs6300::BasicBlock>>
-cs6300::Read::emit()
+cs6300::FlowGraph cs6300::Read::emit()
 {
   auto block = std::make_shared<BasicBlock>();
   for (auto&& val : values)

--- a/AST_INC/AST/Statements/Read.hpp
+++ b/AST_INC/AST/Statements/Read.hpp
@@ -23,7 +23,7 @@ public:
     values.push_back(v);
   }
 
-  std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>> emit();
+  cs6300::FlowGraph emit();
 
 private:
   std::vector<std::shared_ptr<LValue>> values;

--- a/AST_INC/AST/Statements/Repeat.cpp
+++ b/AST_INC/AST/Statements/Repeat.cpp
@@ -1,8 +1,6 @@
 #include "Repeat.hpp"
 
-std::pair<std::shared_ptr<cs6300::BasicBlock>,
-          std::shared_ptr<cs6300::BasicBlock>>
-cs6300::RepeatStatement::emit()
+cs6300::FlowGraph cs6300::RepeatStatement::emit()
 {
   auto b = emitList(body);
   auto expr = condition->emit();

--- a/AST_INC/AST/Statements/Repeat.hpp
+++ b/AST_INC/AST/Statements/Repeat.hpp
@@ -19,7 +19,7 @@ class RepeatStatement : public Statement
           , body(statements)
       {
       }
-      std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>> emit();
+      cs6300::FlowGraph emit();
 
     private:
       std::shared_ptr<Expression> condition;

--- a/AST_INC/AST/Statements/Return.cpp
+++ b/AST_INC/AST/Statements/Return.cpp
@@ -2,9 +2,7 @@
 #include "AST/Type.hpp"
 #include "AST/ThreeAddressInstruction.hpp"
 
-std::pair<std::shared_ptr<cs6300::BasicBlock>,
-          std::shared_ptr<cs6300::BasicBlock>>
-cs6300::ReturnStatement::emit()
+cs6300::FlowGraph cs6300::ReturnStatement::emit()
 {
   auto block = std::make_shared<BasicBlock>();
 

--- a/AST_INC/AST/Statements/Return.hpp
+++ b/AST_INC/AST/Statements/Return.hpp
@@ -17,7 +17,7 @@ public:
       , value(v)
   {
   }
-  std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>> emit();
+  cs6300::FlowGraph emit();
 private:
   std::shared_ptr<Expression> value;
 };

--- a/AST_INC/AST/Statements/Statement.cpp
+++ b/AST_INC/AST/Statements/Statement.cpp
@@ -1,8 +1,6 @@
 #include "Statement.hpp"
 
-std::pair<std::shared_ptr<cs6300::BasicBlock>,
-          std::shared_ptr<cs6300::BasicBlock>>
-cs6300::emitList(std::vector<std::shared_ptr<Statement>> statements)
+cs6300::FlowGraph cs6300::emitList(std::vector<std::shared_ptr<Statement>> statements)
 {
   auto entry = std::make_shared<BasicBlock>();
   auto current = entry;

--- a/AST_INC/AST/Statements/Statement.hpp
+++ b/AST_INC/AST/Statements/Statement.hpp
@@ -9,12 +9,10 @@ namespace cs6300
   {
   public:
     virtual ~Statement()=default;
-    virtual std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>>
-    emit() = 0;
+    virtual cs6300::FlowGraph emit() = 0;
   };
 
-  std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>>
-  emitList(std::vector<std::shared_ptr<Statement>> statements);
+  cs6300::FlowGraph emitList(std::vector<std::shared_ptr<Statement>> statements);
 }
 
 #endif

--- a/AST_INC/AST/Statements/Stop.cpp
+++ b/AST_INC/AST/Statements/Stop.cpp
@@ -1,7 +1,7 @@
 #include "Stop.hpp"
 
 
-  std::pair<std::shared_ptr<cs6300::BasicBlock>, std::shared_ptr<cs6300::BasicBlock>> cs6300::StopStatement::emit()
+cs6300::FlowGraph cs6300::StopStatement::emit()
 {
   auto block = std::make_shared<BasicBlock>();
   block->instructions.push_back(

--- a/AST_INC/AST/Statements/Stop.hpp
+++ b/AST_INC/AST/Statements/Stop.hpp
@@ -11,7 +11,7 @@ public:
   StopStatement() : Statement()
   {
   }
-  std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>> emit();
+  cs6300::FlowGraph emit();
 };
 }
 #endif

--- a/AST_INC/AST/Statements/While.cpp
+++ b/AST_INC/AST/Statements/While.cpp
@@ -1,8 +1,6 @@
 #include "While.hpp"
 
-std::pair<std::shared_ptr<cs6300::BasicBlock>,
-          std::shared_ptr<cs6300::BasicBlock>>
-cs6300::WhileStatement::emit()
+cs6300::FlowGraph cs6300::WhileStatement::emit()
 {
   auto b = emitList(body);
   auto expr = condition->emit();

--- a/AST_INC/AST/Statements/While.hpp
+++ b/AST_INC/AST/Statements/While.hpp
@@ -19,8 +19,7 @@ class WhileStatement : public Statement
           , body(statements)
       {
       }
-      std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>>
-      emit();
+      cs6300::FlowGraph emit();
 
     private:
       std::shared_ptr<Expression> condition;

--- a/AST_INC/AST/Statements/Write.cpp
+++ b/AST_INC/AST/Statements/Write.cpp
@@ -2,9 +2,7 @@
 #include "AST/Type.hpp"
 #include "AST/ThreeAddressInstruction.hpp"
 
-std::pair<std::shared_ptr<cs6300::BasicBlock>,
-          std::shared_ptr<cs6300::BasicBlock>>
-cs6300::Write::emit()
+cs6300::FlowGraph cs6300::Write::emit()
 {
   auto block = std::make_shared<BasicBlock>();
   for (auto&& val : values)

--- a/AST_INC/AST/Statements/Write.hpp
+++ b/AST_INC/AST/Statements/Write.hpp
@@ -22,7 +22,7 @@ public:
   {
     values.push_back(v);
   }
-  std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>> emit();
+  cs6300::FlowGraph emit();
 private:
   std::vector<std::shared_ptr<Expression>> values;
 };

--- a/BackEnd/Allocation.cpp
+++ b/BackEnd/Allocation.cpp
@@ -1,6 +1,7 @@
 #include "Allocation.hpp"
 #include "AST/Program.hpp"
 #include "AST/ThreeAddressInstruction.hpp"
+#include "Optimizations/FlowGraph.h"
 #include <algorithm>
 
 struct RegColorNode
@@ -9,42 +10,6 @@ struct RegColorNode
   std::set<RegColorNode*> nodes;
   std::set<int> cant;
 };
-
-std::set<std::shared_ptr<cs6300::BasicBlock>> allBlocks(
-  cs6300::FlowGraph graph)
-{
-  std::set<std::shared_ptr<cs6300::BasicBlock>> all;
-  std::vector<std::shared_ptr<cs6300::BasicBlock>> todo;
-  auto at = graph.first;
-
-  do
-  {
-    if (todo.size())
-    {
-      at = todo.back();
-      todo.pop_back();
-    }
-
-    while (at)
-    {
-      if (!all.count(at))
-      {
-          all.insert(at);
-      }
-      else
-      {
-          break;
-      }
-
-      if (at->branchTo && !all.count(at->branchTo))
-        todo.emplace_back(at->branchTo);
-
-      at = at->jumpTo;
-    }
-  } while (todo.size());
-
-  return all;
-}
 
 void cs6300::locRegAlloc(cs6300::FlowGraph graph)
 {

--- a/BackEnd/Allocation.cpp
+++ b/BackEnd/Allocation.cpp
@@ -11,12 +11,11 @@ struct RegColorNode
 };
 
 std::set<std::shared_ptr<cs6300::BasicBlock>> allBlocks(
-  std::pair<std::shared_ptr<cs6300::BasicBlock>,
-            std::shared_ptr<cs6300::BasicBlock>> b)
+  cs6300::FlowGraph graph)
 {
   std::set<std::shared_ptr<cs6300::BasicBlock>> all;
   std::vector<std::shared_ptr<cs6300::BasicBlock>> todo;
-  auto at = b.first;
+  auto at = graph.first;
 
   do
   {
@@ -47,12 +46,11 @@ std::set<std::shared_ptr<cs6300::BasicBlock>> allBlocks(
   return all;
 }
 
-void cs6300::locRegAlloc(std::pair<std::shared_ptr<cs6300::BasicBlock>,
-                                   std::shared_ptr<cs6300::BasicBlock>> b)
+void cs6300::locRegAlloc(cs6300::FlowGraph graph)
 {
   int count = 0;
 
-  for (auto&& v : allBlocks(b))
+  for (auto&& v : allBlocks(graph))
     v->initSets();
 
   // propogate block meta
@@ -60,7 +58,7 @@ void cs6300::locRegAlloc(std::pair<std::shared_ptr<cs6300::BasicBlock>,
   do
   {
     change = false;
-    for (auto&& v : allBlocks(b))
+    for (auto&& v : allBlocks(graph))
     {
       if (pushUp(v, v->jumpTo)) change = true;
 
@@ -69,7 +67,7 @@ void cs6300::locRegAlloc(std::pair<std::shared_ptr<cs6300::BasicBlock>,
   } while (change);
 
   std::map<int, RegColorNode*> nodes;
-  for (auto&& cur : allBlocks(b))
+  for (auto&& cur : allBlocks(graph))
   {
     auto t = regDeps(cur);
     auto s = std::set<std::set<int>>(t.begin(), t.end());
@@ -116,7 +114,7 @@ void cs6300::locRegAlloc(std::pair<std::shared_ptr<cs6300::BasicBlock>,
     }
   }
 
-  for (auto&& v : allBlocks(b))
+  for (auto&& v : allBlocks(graph))
   {
     v->remap(regRemap);
   }

--- a/BackEnd/Allocation.hpp
+++ b/BackEnd/Allocation.hpp
@@ -5,12 +5,13 @@
 #include <vector>
 #include <set>
 
+#include "AST/BasicBlock.hpp"
+
 namespace cs6300
 {
 class BasicBlock;
 
-void locRegAlloc(
-  std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>>);
+void locRegAlloc(cs6300::FlowGraph);
 bool pushUp(std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>);
 std::vector<std::set<int>> regDeps(std::shared_ptr<BasicBlock>);
 }

--- a/BackEnd/BackEnd.cpp
+++ b/BackEnd/BackEnd.cpp
@@ -33,8 +33,7 @@ void emitMIPS(std::shared_ptr<cs6300::BasicBlock> block, std::ofstream& fout)
   emitMIPS(block->branchTo, fout);
   emitMIPS(block->jumpTo, fout);
 }
-void emitMIPS(std::pair<std::shared_ptr<cs6300::BasicBlock>,
-                        std::shared_ptr<cs6300::BasicBlock>> cfg,
+void emitMIPS(cs6300::FlowGraph cfg,
               std::ofstream& fout)
 {
   seenBlocks.clear();

--- a/BackEnd/BackEnd.hpp
+++ b/BackEnd/BackEnd.hpp
@@ -5,15 +5,15 @@
 #include <vector>
 #include <set>
 
+#include "AST/BasicBlock.hpp"
+
 namespace cs6300
 {
 class IntermediateRepresentationProgram;
-class BasicBlock;
 
 void writeMIPS(std::shared_ptr<IntermediateRepresentationProgram>,
                std::string filename);
-void locRegAlloc(
-  std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>>);
+void locRegAlloc(cs6300::FlowGraph);
 bool pushUp(std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>);
 std::vector<std::set<int>> regDeps(std::shared_ptr<BasicBlock>);
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,10 @@ BISON_TARGET(CpslParser FrontEnd/parser.y ${CMAKE_CURRENT_BINARY_DIR}/parser.cpp
 FLEX_TARGET(CpslScanner FrontEnd/scanner.l ${CMAKE_CURRENT_BINARY_DIR}/scanner.cpp)
 ADD_FLEX_BISON_DEPENDENCY(CpslScanner CpslParser)
 
-enable_testing()
-
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR} 
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/AST_INC
-    ${gtest_SOURCE_DIR}/include
-    ${gtest_SOURCE_DIR}
     ${WINDOWS_GNU}
     )
 
@@ -166,15 +162,14 @@ Optimizations/MaximizeBlocks/NumParents.hpp
 Optimizations/MaximizeBlocks/NumParents.cpp
 Optimizations/MaximizeBlocks/MaximizeBlocks.hpp
 Optimizations/MaximizeBlocks/MaximizeBlocks.cpp
+Optimizations/FlowGraph.h
+Optimizations/FlowGraph.cpp
 )
 source_group("Optimizations" FILES ${optimization_srcs})
 list(APPEND cpsl_srcs ${optimization_srcs})
 
-file(GLOB unittests Testing/UnitTests/*.cpp)
 list(APPEND cpsl_srcs ${unittests})
 
 add_executable(cpsl ${cpsl_srcs})
 
-target_link_libraries(cpsl ${FLEX_LIBRARIES} ${BISON_LIBRARIES} gtest)
-
-add_test(NAME runUnitTests COMMAND cpsl -test)
+target_link_libraries(cpsl ${FLEX_LIBRARIES} ${BISON_LIBRARIES})

--- a/Optimizations/FlowGraph.cpp
+++ b/Optimizations/FlowGraph.cpp
@@ -20,14 +20,14 @@ std::map<std::shared_ptr<cs6300::BasicBlock>, std::vector<std::shared_ptr<cs6300
                           if (block->jumpTo != nullptr) {
                               parentMap[block->jumpTo].push_back(block);
                           }
-                          
+
                           if (block->branchTo != nullptr) {
                               parentMap[block->branchTo].push_back(block);
                           }
                           return true;
-                          
+
                       });
-    
+
     return parentMap;
 }
 
@@ -36,19 +36,19 @@ void cs6300::traverseFlowGraph(std::shared_ptr<cs6300::BasicBlock> sourceBlock, 
     auto searchBlock = sourceBlock;
     std::set<std::shared_ptr<cs6300::BasicBlock>> seenList;
     std::vector<std::shared_ptr<cs6300::BasicBlock>> visitStack;
-    
+
     visitStack.push_back(nullptr);
-    
+
     while (searchBlock != nullptr) {
-        
+
         if (seenList.find(searchBlock) == seenList.end()) {
             if (!action(searchBlock))
                 continue;
             seenList.insert(searchBlock);
             visitStack.push_back(searchBlock);
         }
-        
-        
+
+
         if (searchBlock->jumpTo != nullptr && seenList.find(searchBlock->jumpTo) == seenList.end()) {
             searchBlock = searchBlock->jumpTo;
         } else if (searchBlock->branchTo != nullptr && seenList.find(searchBlock->branchTo) == seenList.end()) {
@@ -57,8 +57,8 @@ void cs6300::traverseFlowGraph(std::shared_ptr<cs6300::BasicBlock> sourceBlock, 
             searchBlock = visitStack.back();
             visitStack.pop_back();
         }
-        
-        
+
+
     }
 }
 

--- a/Optimizations/FlowGraph.cpp
+++ b/Optimizations/FlowGraph.cpp
@@ -3,61 +3,60 @@
 // I should probably just add this as a property of basic block but I am paranoid about code merges.
 std::map<std::shared_ptr<cs6300::BasicBlock>, std::vector<std::shared_ptr<cs6300::BasicBlock>>> cs6300::buildParentMap(std::shared_ptr<cs6300::BasicBlock> flowGraph)
 {
-    std::map<std::shared_ptr<cs6300::BasicBlock>, std::vector<std::shared_ptr<cs6300::BasicBlock>>> parentMap;
-    traverseFlowGraph(flowGraph, [&parentMap](std::shared_ptr<cs6300::BasicBlock> block)->bool
-                      {
-                          if (block->jumpTo != nullptr) {
-                              parentMap[block->jumpTo].push_back(block);
-                          }
+  std::map<std::shared_ptr<cs6300::BasicBlock>, std::vector<std::shared_ptr<cs6300::BasicBlock>>> parentMap;
+  traverseFlowGraph(flowGraph, [&parentMap](std::shared_ptr<cs6300::BasicBlock> block)->bool
+      {
+      if (block->jumpTo != nullptr) {
+      parentMap[block->jumpTo].push_back(block);
+      }
 
-                          if (block->branchTo != nullptr) {
-                              parentMap[block->branchTo].push_back(block);
-                          }
-                          return true;
+      if (block->branchTo != nullptr) {
+      parentMap[block->branchTo].push_back(block);
+      }
+      return true;
 
-                      });
+      });
 
-    return parentMap;
+  return parentMap;
 }
 
 
 void cs6300::traverseFlowGraph(std::shared_ptr<cs6300::BasicBlock> sourceBlock, std::function<bool(std::shared_ptr<cs6300::BasicBlock>)> action) {
-    auto searchBlock = sourceBlock;
-    std::set<std::shared_ptr<cs6300::BasicBlock>> seenList;
-    std::vector<std::shared_ptr<cs6300::BasicBlock>> visitStack;
+  auto searchBlock = sourceBlock;
+  std::set<std::shared_ptr<cs6300::BasicBlock>> seenList;
+  std::vector<std::shared_ptr<cs6300::BasicBlock>> visitStack;
 
-    visitStack.push_back(nullptr);
+  visitStack.push_back(nullptr);
 
-    while (searchBlock != nullptr) {
+  while (searchBlock != nullptr) {
 
-        if (seenList.find(searchBlock) == seenList.end()) {
-            if (!action(searchBlock))
-                continue;
-            seenList.insert(searchBlock);
-            visitStack.push_back(searchBlock);
-        }
-
-
-        if (searchBlock->jumpTo != nullptr && seenList.find(searchBlock->jumpTo) == seenList.end()) {
-            searchBlock = searchBlock->jumpTo;
-        } else if (searchBlock->branchTo != nullptr && seenList.find(searchBlock->branchTo) == seenList.end()) {
-            searchBlock = searchBlock->branchTo;
-        } else {
-            searchBlock = visitStack.back();
-            visitStack.pop_back();
-        }
-
-
+    if (seenList.find(searchBlock) == seenList.end()) {
+      if (!action(searchBlock))
+        continue;
+      seenList.insert(searchBlock);
+      visitStack.push_back(searchBlock);
     }
+
+
+    if (searchBlock->jumpTo != nullptr && seenList.find(searchBlock->jumpTo) == seenList.end()) {
+      searchBlock = searchBlock->jumpTo;
+    } else if (searchBlock->branchTo != nullptr && seenList.find(searchBlock->branchTo) == seenList.end()) {
+      searchBlock = searchBlock->branchTo;
+    } else {
+      searchBlock = visitStack.back();
+      visitStack.pop_back();
+    }
+
+
+  }
 }
 
 std::set<std::shared_ptr<cs6300::BasicBlock>> cs6300::allBlocks(
-  cs6300::FlowGraph graph)
+    cs6300::FlowGraph graph)
 {
   std::set<std::shared_ptr<cs6300::BasicBlock>> all;
   std::vector<std::shared_ptr<cs6300::BasicBlock>> todo;
   auto at = graph.first;
-
   do
   {
     if (todo.size())
@@ -65,25 +64,28 @@ std::set<std::shared_ptr<cs6300::BasicBlock>> cs6300::allBlocks(
       at = todo.back();
       todo.pop_back();
     }
-
     while (at)
     {
       if (!all.count(at))
       {
-          all.insert(at);
+        all.insert(at);
       }
       else
       {
-          break;
+        break;
       }
-
       if (at->branchTo && !all.count(at->branchTo))
+      {
+        at->branchTo->parents.insert(at);
         todo.emplace_back(at->branchTo);
-
+      }
+      if(at->jumpTo)
+      {
+        at->jumpTo->parents.insert(at);
+      }
       at = at->jumpTo;
     }
   } while (todo.size());
-
   return all;
 }
 
@@ -101,7 +103,7 @@ std::string cs6300::flowGraphDot(cs6300::FlowGraph graph)
   std::string digraph =  "digraph G {";
 
   for(auto& s : edges)
-    digraph += s;
+    digraph += s + "\n";
 
-  return digraph + "\n}";
+  return digraph + "}";
 }

--- a/Optimizations/FlowGraph.h
+++ b/Optimizations/FlowGraph.h
@@ -1,28 +1,17 @@
-//
-//  TraverseBasicBlock.h
-//  cpsl
-//
-//  Created by Steve Goodrich on 10/10/14.
-//
-//
-
 #ifndef __cpsl__TraverseBasicBlock__
 #define __cpsl__TraverseBasicBlock__
-
-#include <stdio.h>
-#include <memory>
-#include <functional>
-#include <set>
-#include <map>
 
 #include "AST/BasicBlock.hpp"
 
 namespace cs6300 {
-
-
 std::map<std::shared_ptr<cs6300::BasicBlock>, std::vector<std::shared_ptr<cs6300::BasicBlock>>> buildParentMap(std::shared_ptr<cs6300::BasicBlock> flowGraph);
 
 void traverseFlowGraph(std::shared_ptr<cs6300::BasicBlock> sourceBlock, std::function<bool(std::shared_ptr<cs6300::BasicBlock>)>  action);
+
+/* Generate a Dot file for the given cs6300::FlowGraph */
+std::string flowGraphDot(cs6300::FlowGraph);
+
+std::set<std::shared_ptr<cs6300::BasicBlock>> allBlocks(cs6300::FlowGraph graph);
 }
 
 #endif /* defined(__cpsl__TraverseBasicBlock__) */

--- a/Optimizations/MaximizeBlocks/MaximizeBlocks.cpp
+++ b/Optimizations/MaximizeBlocks/MaximizeBlocks.cpp
@@ -6,8 +6,7 @@
 #include "VisitedBlocks.hpp"
 #include "NumParents.hpp"
 
-void cs6300::maximizeBlocks(std::pair<std::shared_ptr<cs6300::BasicBlock>,
-                            std::shared_ptr<cs6300::BasicBlock>> original)
+void cs6300::maximizeBlocks(cs6300::FlowGraph original)
 {
   // traverse the blocks
   cs6300::traverse(original.first);

--- a/Optimizations/MaximizeBlocks/MaximizeBlocks.hpp
+++ b/Optimizations/MaximizeBlocks/MaximizeBlocks.hpp
@@ -7,16 +7,15 @@
 #include <map>
 #include <vector>
 
-#include "../../AST_INC/AST/BasicBlock.hpp"
-#include "../../AST_INC/AST/ThreeAddressInstruction.hpp"
+#include "AST/BasicBlock.hpp"
+#include "AST/ThreeAddressInstruction.hpp"
 
 namespace cs6300
 {
-  void maximizeBlocks(std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>>);
+  void maximizeBlocks(cs6300::FlowGraph);
 
   void traverse(std::shared_ptr<BasicBlock> block);
 }
-
 
 #endif
 

--- a/Optimizations/Optimizer.cpp
+++ b/Optimizations/Optimizer.cpp
@@ -10,10 +10,7 @@ cs6300::optimizer(std::shared_ptr<cs6300::Program> original)
   return original;
 }
 /*Add new control flow graph based optimizations here*/
-std::pair<std::shared_ptr<cs6300::BasicBlock>,
-          std::shared_ptr<cs6300::BasicBlock>>
-cs6300::optimizer(std::pair<std::shared_ptr<cs6300::BasicBlock>,
-                            std::shared_ptr<cs6300::BasicBlock>> original)
+cs6300::FlowGraph cs6300::optimizer(cs6300::FlowGraph original)
 {
   maximizeBlocks(original);
   return original;

--- a/Optimizations/Optimizer.hpp
+++ b/Optimizations/Optimizer.hpp
@@ -3,15 +3,15 @@
 
 #include <memory>
 
+#include "AST/BasicBlock.hpp"
+
 namespace cs6300
 {
 class Program;
-class BasicBlock;
 /*Returns the Abstract Syntax Tree that is the result of parsing filename*/
 std::shared_ptr<Program> optimizer(std::shared_ptr<Program>);
 /*Returns an improved control flow graph*/
-std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>> optimizer(
-  std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>>);
+cs6300::FlowGraph optimizer(cs6300::FlowGraph);
 }
 
 #endif

--- a/README
+++ b/README
@@ -1,0 +1,6 @@
+To generate flowgraph use the -f option. The flowgraph will print to stdout allowing piping.
+    ./cpsl -f foo.cpsl
+To view as a graphviz try the following: (with dot and feh installed)
+    ./cpsl -f foo.cpsl | dot -Tpng | feh -
+
+This documentation will be more fully developed and formatted in the future.

--- a/Testing/UnitTests/AllocationTest.cpp
+++ b/Testing/UnitTests/AllocationTest.cpp
@@ -43,8 +43,7 @@ TEST(AllocationTest, validateSets)
     b5->instructions.push_back(cs6300::ThreeAddressInstruction(cs6300::ThreeAddressInstruction::LoadValue, 10, 1, 0));
     b5->instructions.push_back(cs6300::ThreeAddressInstruction(cs6300::ThreeAddressInstruction::Add, 11, 9, 10));
 
-    auto blocks = std::pair<std::shared_ptr<cs6300::BasicBlock>,
-            std::shared_ptr<cs6300::BasicBlock>>(b0, b5);
+    auto blocks = cs6300::FlowGraph(b0, b5);
 
     cs6300::locRegAlloc(blocks);
 

--- a/Testing/UnitTests/MaximizingBlocksTest.cpp
+++ b/Testing/UnitTests/MaximizingBlocksTest.cpp
@@ -53,10 +53,7 @@ TEST(maximizingBlocksTest, complexMerge)
     b5->instructions.push_back(cs6300::ThreeAddressInstruction(cs6300::ThreeAddressInstruction::Add, 11, 9, 10));
     b5->instructions.push_back(cs6300::ThreeAddressInstruction(cs6300::ThreeAddressInstruction::StoreMemory, 11, 1, 0));
 
-
-
-    auto blocks = std::pair<std::shared_ptr<cs6300::BasicBlock>,
-            std::shared_ptr<cs6300::BasicBlock>>(b0, b6);
+    auto blocks = cs6300::FlowGraph(b0, b6);
 
     cs6300::maximizeBlocks(blocks);
 
@@ -94,8 +91,7 @@ TEST(maximizingBlocksTest, simpleMerge)
     b1->instructions.push_back(cs6300::ThreeAddressInstruction(cs6300::ThreeAddressInstruction::Modulo, 7, 2, 5));
     b1->instructions.push_back(cs6300::ThreeAddressInstruction(cs6300::ThreeAddressInstruction::StoreMemory, 7, 2, 0));
 
-    auto blocks = std::pair<std::shared_ptr<cs6300::BasicBlock>,
-            std::shared_ptr<cs6300::BasicBlock>>(b0, b1);
+    auto blocks = cs6300::FlowGraph(b0, b1);
 
     EXPECT_EQ(1, b0->instructions.size());
     EXPECT_NE(nullptr, b0->jumpTo);
@@ -131,8 +127,7 @@ TEST(maximizingBlocksTest, threeBlockeMergeCheckOrder)
     b2->instructions.push_back(cs6300::ThreeAddressInstruction(cs6300::ThreeAddressInstruction::Modulo, 7, 2, 5));
     b2->instructions.push_back(cs6300::ThreeAddressInstruction(cs6300::ThreeAddressInstruction::StoreMemory, 7, 2, 0));
 
-    auto blocks = std::pair<std::shared_ptr<cs6300::BasicBlock>,
-            std::shared_ptr<cs6300::BasicBlock>>(b0, b2);
+    auto blocks = cs6300::FlowGraph(b0, b2);
 
     EXPECT_EQ(1, b0->instructions.size());
     EXPECT_NE(nullptr, b0->jumpTo);


### PR DESCRIPTION
This is a type we use extensively throughout the project. It has
significant meaning and we may want it to become a full blown class
someday.

A flowgraph is generated before any optimizations with the -f option.
The flowgraph is output on stdout as a dot digraph.
If you want the flowgraph to generate after all optimizations use the -F
flag.